### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,9 @@ If you like Tequila, consider [buying me a beer](https://www.paypal.com/cgi-bin/
 
 
 [logo]: ../graphics/logo.png?raw=true
-[downloads]: https://pypip.in/d/tequila/badge.svg
-[python_versions]: https://pypip.in/py_versions/tequila/badge.svg
-[license]: https://pypip.in/license/tequila/badge.svg
+[downloads]: https://img.shields.io/pypi/dm/tequila.svg
+[python_versions]: https://img.shields.io/pypi/pyversions/tequila.svg
+[license]: https://img.shields.io/pypi/l/tequila.svg
 
 [pypi]: https://pypi.python.org/pypi/tequila/
 [python]: https://www.python.org/


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20tequila))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `tequila`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.